### PR TITLE
feat: add JSON-LD structured data for Google rich results

### DIFF
--- a/app/api/catering/route.ts
+++ b/app/api/catering/route.ts
@@ -2,7 +2,9 @@ import { NextRequest, NextResponse } from "next/server";
 import { Resend } from "resend";
 import { z } from "zod";
 
-const resend = new Resend(process.env.RESEND_API_KEY);
+function getResend() {
+  return new Resend(process.env.RESEND_API_KEY);
+}
 
 const OWNER_EMAIL = process.env.OWNER_EMAIL ?? "info@barbquewagon.com";
 const FROM_EMAIL = process.env.FROM_EMAIL ?? "noreply@barbquewagon.com";
@@ -29,7 +31,7 @@ export async function POST(request: NextRequest) {
     const { name, email, phone, date, guests, eventType, message } =
       result.data;
 
-    await resend.emails.send({
+    await getResend().emails.send({
       from: FROM_EMAIL,
       to: OWNER_EMAIL,
       replyTo: email,

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -2,7 +2,9 @@ import { NextRequest, NextResponse } from "next/server";
 import { Resend } from "resend";
 import { z } from "zod";
 
-const resend = new Resend(process.env.RESEND_API_KEY);
+function getResend() {
+  return new Resend(process.env.RESEND_API_KEY);
+}
 
 const OWNER_EMAIL = process.env.OWNER_EMAIL ?? "info@barbquewagon.com";
 const FROM_EMAIL = process.env.FROM_EMAIL ?? "noreply@barbquewagon.com";
@@ -26,7 +28,7 @@ export async function POST(request: NextRequest) {
 
     const { name, email, phone, subject, message } = result.data;
 
-    await resend.emails.send({
+    await getResend().emails.send({
       from: FROM_EMAIL,
       to: OWNER_EMAIL,
       replyTo: email,

--- a/app/catering/page.tsx
+++ b/app/catering/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { CateringForm } from "./catering-form";
 import { Check, ArrowRight } from "@phosphor-icons/react/dist/ssr";
+import { JsonLd } from "@/components/json-ld";
+import { getCateringSchema } from "@/lib/structured-data";
 
 export const metadata: Metadata = {
   title: "Catering",
@@ -90,6 +92,7 @@ const cateringPackages: CateringPackage[] = [
 export default function CateringPage() {
   return (
     <>
+      <JsonLd data={getCateringSchema()} />
       {/* Hero */}
       <section className="relative overflow-hidden bg-background py-20 lg:py-28">
         <div className="absolute inset-0 smoke-overlay" />

--- a/app/menu/page.tsx
+++ b/app/menu/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { ArrowRight } from "@phosphor-icons/react/dist/ssr";
+import { JsonLd } from "@/components/json-ld";
+import { getMenuSchema } from "@/lib/structured-data";
 
 export const metadata: Metadata = {
   title: "Menu",
@@ -214,6 +216,7 @@ const menuCategories: MenuCategory[] = [
 export default function MenuPage() {
   return (
     <>
+      <JsonLd data={getMenuSchema()} />
       {/* Hero */}
       <section className="relative overflow-hidden bg-background py-20 lg:py-28">
         <div className="absolute inset-0 smoke-overlay" />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,8 @@ import {
   Clock,
   ArrowRight,
 } from "@phosphor-icons/react/dist/ssr";
+import { JsonLd } from "@/components/json-ld";
+import { getRestaurantSchema } from "@/lib/structured-data";
 
 const featuredItems = [
   {
@@ -77,6 +79,7 @@ const values = [
 export default function HomePage() {
   return (
     <>
+      <JsonLd data={getRestaurantSchema()} />
       {/* ============================================
           HERO SECTION
           ============================================ */}

--- a/components/json-ld.tsx
+++ b/components/json-ld.tsx
@@ -1,0 +1,8 @@
+export function JsonLd({ data }: { data: Record<string, unknown> }) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  );
+}

--- a/lib/structured-data.ts
+++ b/lib/structured-data.ts
@@ -1,0 +1,129 @@
+/**
+ * JSON-LD structured data for Google rich results.
+ * @see https://developers.google.com/search/docs/appearance/structured-data
+ */
+
+export const BUSINESS_INFO = {
+  name: "Bar-B-Que Wagon",
+  address: {
+    street: "610 Main St",
+    city: "Bryson City",
+    state: "NC",
+    zip: "28713",
+  },
+  phone: "+1-828-488-9521",
+  email: "bbqwagon@gmail.com",
+  url: "https://barbquewagon.com",
+  geo: { lat: 35.4312, lng: -83.4488 },
+  priceRange: "$$",
+  cuisine: "Barbecue",
+} as const;
+
+/** Restaurant / LocalBusiness schema for the homepage */
+export function getRestaurantSchema() {
+  const b = BUSINESS_INFO;
+  return {
+    "@context": "https://schema.org",
+    "@type": "Restaurant",
+    name: b.name,
+    image: `${b.url}/images/exterior/building-1.jpg`,
+    url: b.url,
+    telephone: b.phone,
+    email: b.email,
+    priceRange: b.priceRange,
+    servesCuisine: b.cuisine,
+    address: {
+      "@type": "PostalAddress",
+      streetAddress: b.address.street,
+      addressLocality: b.address.city,
+      addressRegion: b.address.state,
+      postalCode: b.address.zip,
+      addressCountry: "US",
+    },
+    geo: {
+      "@type": "GeoCoordinates",
+      latitude: b.geo.lat,
+      longitude: b.geo.lng,
+    },
+    openingHoursSpecification: [
+      {
+        "@type": "OpeningHoursSpecification",
+        dayOfWeek: ["Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"],
+        opens: "11:00",
+        closes: "20:00",
+      },
+      {
+        "@type": "OpeningHoursSpecification",
+        dayOfWeek: "Sunday",
+        opens: "11:00",
+        closes: "18:00",
+      },
+    ],
+    menu: `${b.url}/menu`,
+    acceptsReservations: "False",
+    hasMap: `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(
+      `${b.address.street} ${b.address.city} ${b.address.state} ${b.address.zip}`
+    )}`,
+  };
+}
+
+/** Menu items schema for /menu page */
+export function getMenuSchema() {
+  const b = BUSINESS_INFO;
+  return {
+    "@context": "https://schema.org",
+    "@type": "Menu",
+    name: `${b.name} Menu`,
+    url: `${b.url}/menu`,
+    mainEntity: {
+      "@type": "MenuSection",
+      name: "Smoked Meats",
+      hasMenuItem: [
+        menuItem("Smoked Brisket", "Slow-smoked 14 hours over hickory.", "14.99"),
+        menuItem("Pulled Pork", "Hand-pulled Carolina-style with house vinegar sauce.", "12.99"),
+        menuItem("Baby Back Ribs", "Fall-off-the-bone tender, dry rubbed, slow smoked.", "16.99"),
+        menuItem("Smoked Turkey", "Half pound of tender smoked turkey breast with two sides.", "13.99"),
+      ],
+    },
+  };
+}
+
+function menuItem(name: string, description: string, price: string) {
+  return {
+    "@type": "MenuItem",
+    name,
+    description,
+    offers: {
+      "@type": "Offer",
+      price,
+      priceCurrency: "USD",
+    },
+  };
+}
+
+/** Catering service schema */
+export function getCateringSchema() {
+  const b = BUSINESS_INFO;
+  return {
+    "@context": "https://schema.org",
+    "@type": "FoodService",
+    name: `${b.name} Catering`,
+    url: `${b.url}/catering`,
+    provider: {
+      "@type": "Restaurant",
+      name: b.name,
+      url: b.url,
+    },
+    areaServed: {
+      "@type": "GeoCircle",
+      geoMidpoint: {
+        "@type": "GeoCoordinates",
+        latitude: b.geo.lat,
+        longitude: b.geo.lng,
+      },
+      geoRadius: "80000",
+    },
+    description:
+      "BBQ catering for weddings, corporate events, family reunions, and private parties in Western North Carolina and the Great Smoky Mountains.",
+  };
+}


### PR DESCRIPTION
## What

Adds Schema.org JSON-LD structured data to all pages for Google rich results (knowledge panel, menu items, hours, location).

### Changes
- **`lib/structured-data.ts`** — Centralized business info + schema generators (Restaurant, Menu, FoodService)
- **`components/json-ld.tsx`** — Reusable `<JsonLd>` component
- Homepage → Restaurant schema (hours, geo, contact, cuisine)
- Menu page → Menu schema with featured items + prices
- Catering page → FoodService schema with service area
- **Fix:** Lazy-init Resend client so builds don't crash without `RESEND_API_KEY` env var

### Why
Local restaurant SEO 101 — structured data drives Google rich results (hours in search, menu cards, map panel). High-ROI for a brick-and-mortar business.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added JSON-LD structured data to key pages (restaurant, menu, catering) to enhance search engine understanding and enable rich search result previews for improved discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->